### PR TITLE
fix error in contact view when company_phone is nil

### DIFF
--- a/app/views/layouts/_contact.html.erb
+++ b/app/views/layouts/_contact.html.erb
@@ -13,7 +13,7 @@
 
     <div class="address2">
       <%= mail_to contact.company_email.value if contact.company_email %><br />
-      <%= contact.company_phone.value %>
+      <%= contact.company_phone.value if contact.company_phone %>
     </div>
 
     <div class="actions">


### PR DESCRIPTION
Login fails if one of the user's contacts (admin in my case) lacks a `company_phone`.